### PR TITLE
Added sort_like to enumerable.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -80,22 +80,19 @@ then rock the house by requiring it. It sets itself up!
 
 ###I have an array of objects, and I'd like to sort them based on another enumerable.
 
-  class Thingy
-    def initialize(foo)
-      self.foo = foo
+    class Thingy
+      def initialize(foo)
+        self.foo = foo
+      end
+      attr_accessor :foo
     end
-    attr_accessor :foo
-  end
 
-  thingies = [Thingy.new("abc"), Thingy.new("def"), Thingy.new("ghi")]
+    thingies = [Thingy.new("abc"), Thingy.new("def"), Thingy.new("ghi")]
+    arry = ["def", "abc", "ghi"]
 
-  arry = ["def", "abc", "ghi"]
-
-  thingies.sort_like(arry, :foo)
-
-  # OR
-
-  thingies.sort_like(arry) { |t| t.foo }
+    thingies.sort_like(arry, :foo)
+    # OR
+    thingies.sort_like(arry) { |t| t.foo }
 
 ## Is this useful?
 YES!!!!! Use it.

--- a/README.markdown
+++ b/README.markdown
@@ -78,6 +78,25 @@ then rock the house by requiring it. It sets itself up!
     converter.map_over [1,2,3], :hellos
     # => ["hello", "hellohello", "hellohellohello"]
 
+###I have an array of objects, and I'd like to sort them based on another enumerable.
+
+  class Thingy
+    def initialize(foo)
+      self.foo = foo
+    end
+    attr_accessor :foo
+  end
+
+  thingies = [Thingy.new("abc"), Thingy.new("def"), Thingy.new("ghi")]
+
+  arry = ["def", "abc", "ghi"]
+
+  thingies.sort_like(arry, :foo)
+
+  # OR
+
+  thingies.sort_like(arry) { |t| t.foo }
+
 ## Is this useful?
 YES!!!!! Use it.
 

--- a/lib/enumeradical/core_extensions/enumerable.rb
+++ b/lib/enumeradical/core_extensions/enumerable.rb
@@ -9,6 +9,13 @@ module Enumerable
     do_map to, :new
   end
 
+  def sort_like(arr, method = nil, &block)
+    sorted = arr.map { |a|
+      find { |s| (method ? s.send(method) : Proc.new(&block).call(s)) == a }
+    }.compact
+    sorted + (self - sorted)
+  end
+
 private
   def do_map(obj, method)
     return self unless obj

--- a/spec/core_extensions/enumerable_spec.rb
+++ b/spec/core_extensions/enumerable_spec.rb
@@ -57,5 +57,48 @@ describe "CoreExtensions::Enumerable" do
       end
     end
   end
+
+  describe "#sort_like" do
+
+    class Sortable
+      def initialize(arg)
+        self.arg = arg
+      end
+      attr_accessor :arg
+    end
+
+    before do
+      @sample_array = [Sortable.new(14), Sortable.new(24), Sortable.new(34), Sortable.new(44)]
+      @template_array = [24, 44, 14, 34]
+    end
+
+    example "sorts like the template using the given method name" do
+      sorted = @sample_array.sort_like(@template_array, :arg)
+      sorted.map(&:arg).should == @template_array
+    end
+
+    example "sorts like the template using the given block" do
+      sorted = @sample_array.sort_like(@template_array) { |x| x.arg }
+      sorted.map(&:arg).should == @template_array
+    end
+
+    example "sorts correctly even if template array includes extra items" do
+      @template_array = ([54] + @template_array + [4])
+      sorted = @sample_array.sort_like(@template_array, :arg)
+      sorted.map(&:arg).should == (@template_array - [4, 54])
+    end
+
+    example "sorts correctly even if the template array includes fewer items" do
+      @template_array = (@template_array - [14])
+      sorted = @sample_array.sort_like(@template_array) { |x| x.arg }
+      sorted.map(&:arg).should == [24, 44, 34, 14]
+    end
+
+    example "raises an error if the item doesn't respond to the given method" do
+      lambda {
+        @sample_array.sort_like(@template_array, :foo)
+      }.should raise_error(NoMethodError)
+    end
+  end
 end
 


### PR DESCRIPTION
This is something I have to do every now and then and it always results in some gnarly code.  The use case is basically given an array of identifiers, I'd like to sort this other array of things in the order of the first array.  My particular driving force was the need to pass a list of IDs to a finder in Mongo which unfortunately always returns the result set in the database order regardless of the array passed to the finder.  Anyway, love the library.
